### PR TITLE
Adds support for info commands

### DIFF
--- a/mason.py
+++ b/mason.py
@@ -18,6 +18,7 @@ class Config(object):
     def __init__(self):
         self.verbose = False
         self.no_colorize = False
+        self.output = None
 
 pass_config = click.make_pass_decorator(Config, ensure=True)
 
@@ -144,6 +145,34 @@ def build(config, project, version):
         click.echo('Starting build for {}:{}...'.format(project, version))
     if not config.mason.build(project, version):
         exit('Unable to start build')
+
+
+@cli.group()
+@click.option('--output', type=click.Choice(('text', 'json')), default='text', help='Output format of the command')
+@pass_config
+def info(config, output):
+    """Get info from various services."""
+    config.output = output
+
+
+@info.command()
+@click.option('--build-id', help='Optional build id')
+@pass_config
+def build(config, build_id):
+    """Get info about builds.
+    """
+    if not config.mason.build_info(build_id, config.output):
+        exit('Unable to get build info')
+
+
+@info.command()
+@click.option('--type', 'artifact_type', help='Artifact type to show', default=None)
+@pass_config
+def artifact(config, artifact_type):
+    """Get info about artifacts.
+    """
+    if not config.mason.artifact_info(artifact_type, output=config.output):
+        exit('Unable to get apk info')
 
 
 @cli.group()

--- a/mason.py
+++ b/mason.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python2
+import sys
+
 import getpass
 import pkg_resources
 import click
@@ -95,7 +97,8 @@ def apk(config, apks):
         if config.verbose:
             click.echo('Registering {}...'.format(app))
         if config.mason.parse_apk(app):
-            config.mason.register(app)
+            if not config.mason.register(app):
+                sys.exit(1)
 
 
 @register.command()
@@ -116,7 +119,8 @@ def config(config, yamls):
         if config.verbose:
             click.echo('Registering {}...'.format(yaml))
         if config.mason.parse_os_config(yaml):
-            config.mason.register(yaml)
+            if not config.mason.register(yaml):
+                sys.exit(1)
 
 
 @register.command()
@@ -140,7 +144,8 @@ def media(config, binary, name, type, version):
     if config.verbose:
         click.echo('Registering {}...'.format(binary))
     if config.mason.parse_media(name, type, version, binary):
-        config.mason.register(binary, legacy=True)
+        if not config.mason.register(binary, legacy=True):
+            sys.exit(1)
 
 
 @cli.command()
@@ -287,7 +292,8 @@ def stage(config, skip_verify, yaml):
     if config.verbose:
         click.echo('Staging {}...'.format(yaml))
     if config.mason.parse_os_config(yaml):
-        config.mason.stage(yaml)
+        if not config.mason.stage(yaml):
+            sys.exit(1)
 
 
 @cli.command()

--- a/mason.py
+++ b/mason.py
@@ -5,6 +5,7 @@ import click
 import requests
 import colorama
 
+import masonlib.external.apk_parse.apk
 from masonlib.platform import Platform
 from masonlib.imason import IMason
 
@@ -43,6 +44,29 @@ your configurations and packages to your devices in the field."""
     config.mason = platform.get(IMason)
     config.mason.set_id_token(id_token)
     config.mason.set_access_token(access_token)
+
+
+@cli.group()
+@pass_config
+def apk(config):
+    """APK commands"""
+    pass
+
+
+@apk.command(help='get a key value from the specified apk')
+@click.argument(
+    'key',
+    type=click.Choice(('versionName', 'versionCode', 'package')))
+@click.argument('apk')
+@pass_config
+def get(config, apk, key):
+    apk_obj = masonlib.external.apk_parse.apk.APK(apk)
+    key_map = {
+        'versionName': apk_obj.get_androidversion_name(),
+        'versionCode': apk_obj.get_androidversion_code(),
+        'package': apk_obj.get_package()
+    }
+    print(key_map[key])
 
 
 @cli.group()


### PR DESCRIPTION
* Adds build id display to build command
* Adds support group to cli
* Adds build to command to support group. This command lists the status
of the current builds
* Adds --output command for selecting output format

Examples:
```
> mason status --output=json build
[{"id": "<id>", "project": "<project>", "version": "<version>" ...]

> mason status build
Build #1
  Id: <id>
  Project: <project>
  Version: <version>
  Status: COMPLETED
  Result: SUCCESS
  Submitted: 2018-01-01 12:00:00
  Updated: 2018-02-01 12:00:00
```